### PR TITLE
ci: improve test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@ name: test
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+    - "./docs"
+    - "**/*.md"
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+    - "./docs"
+    - "**/*.md"
 
 env:
   IN_CI: true
@@ -17,6 +23,8 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v4
+      with:
+          go-version: '1.20'
 
     - name: Build
       run: make build-so
@@ -31,6 +39,8 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v4
+      with:
+          go-version: '1.20'
 
     - name: Set up services
       run: |

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ gen-proto: build-dev-tools $(GO_TARGETS)
 unit-test:
 	go test ${TEST_OPTION} $(shell go list ./... | grep -v tests/)
 
+# We can't specify -race to `go build` because it seems that
+# race detector assumes that the executable is loaded around the 0 address. When loaded by the Envoy,
+# the race detector will allocate memory out of 48bits address which is not allowed in x64.
 .PHONY: build-test-so-local
 build-test-so-local:
 	CGO_ENABLED=1 go build -tags so \


### PR DESCRIPTION
1. ignore docs
2. test with the min supported Go version