### PR TITLE
use local go module cache to reduce CI time & avoid CI failure caused by dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
+        # working-directory doesn't affect the cache path
+        cache-dependency-path: ./controller/go.sum
 
     - name: Test
       run: make test


### PR DESCRIPTION
Also fix indentations.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>