### PR TITLE
Handle HTTPRoute directly according to its spec

### DIFF
--- a/controller/internal/translation/data_plane_state.go
+++ b/controller/internal/translation/data_plane_state.go
@@ -234,13 +234,6 @@ func toDataPlaneState(ctx *Ctx, state *InitState) (*FinalState, error) {
 				ls := ls
 				matched := false
 				for _, ref := range route.HTTPRoute.Spec.ParentRefs {
-					if ref.Name != gwapiv1.ObjectName(gw.Name) {
-						continue
-					}
-					if ref.Namespace != nil && *ref.Namespace != gwapiv1.Namespace(gw.Namespace) {
-						continue
-					}
-					// no need to check Group & Kind as we already handle Gateway
 					if ref.Port != nil && *ref.Port != ls.Port {
 						continue
 					}

--- a/controller/internal/translation/testdata/translation/httproute.in.yml
+++ b/controller/internal/translation/testdata/translation/httproute.in.yml
@@ -3,7 +3,7 @@ gateway:
   kind: Gateway
   metadata:
     name: gateway
-    namespace: istio-ingress
+    namespace: default
   spec:
     gatewayClassName: istio
     listeners:
@@ -31,8 +31,6 @@ httproute:
         parentRefs:
         - name: gateway
           namespace: default
-        - name: gateway
-          namespace: istio-ingress
           port: 1234
           sectionName: "sub"
         hostnames: ["htnn.exp.com", "default.local"]

--- a/controller/tests/integration/controller/suite_test.go
+++ b/controller/tests/integration/controller/suite_test.go
@@ -56,10 +56,6 @@ var ctx context.Context
 var cancel context.CancelFunc
 var clientset *kubernetes.Clientset
 
-func ptrstr(s string) *string {
-	return &s
-}
-
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 

--- a/controller/tests/integration/controller/testdata/httpfilterpolicy/httproute_without_gateway.yml
+++ b/controller/tests/integration/controller/testdata/httpfilterpolicy/httproute_without_gateway.yml
@@ -1,0 +1,33 @@
+- apiVersion: mosn.io/v1
+  kind: HTTPFilterPolicy
+  metadata:
+    name: policy
+    namespace: default
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hr
+    filters:
+      demo:
+        config:
+          hostName: goldfish
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: hr
+    namespace: default
+  spec:
+    parentRefs:
+    - name: default
+      namespace: istio-ingress # cross namespace is unsupported
+    hostnames:
+      - default.local
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: default
+        port: 8000


### PR DESCRIPTION
The previous way can't handle HTTPRoute in time, as the status is written after istio has processed the resource.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>