### PR TITLE
Don't hardcode the project root location

### DIFF
--- a/api/plugins/tests/integration/data_plane/data_plane.go
+++ b/api/plugins/tests/integration/data_plane/data_plane.go
@@ -221,9 +221,8 @@ func StartDataPlane(t *testing.T, opt *Option) (*DataPlane, error) {
 
 func (dp *DataPlane) root() string {
 	pwd, _ := os.Getwd()
-	projectRoot := filepath.Join(pwd, "..", "..", "..")
 	name := dp.t.Name()
-	dir := filepath.Join(projectRoot, testRootDirName, name)
+	dir := filepath.Join(pwd, testRootDirName, name)
 	return dir
 }
 

--- a/site/content/en/docs/developer-guide/plugin_integration_test_framework.md
+++ b/site/content/en/docs/developer-guide/plugin_integration_test_framework.md
@@ -9,7 +9,8 @@ Assumed you are at the `./plugins`:
 1. Run `make build-test-so` to build the Go plugins.
 2. Run `go test -v ./tests/integration -run TestPluginXX` to run the selected tests.
 
-The test framework will start Envoy to run the Go plugins. The stdout/stderr of the Envoy can be found in `./test-envoy/$test_name`.
+The test framework will start Envoy to run the Go plugins. The stdout/stderr of the Envoy can be found in `$test_dir/test-envoy/$test_name`.
+The `$test_dir` is where the test files locate, which is `./tests/integration` in this case.
 
 Some tests require third-party services. You can start them by running `docker-compose up $service` under `./tests/integration/testdata/services`.
 

--- a/site/content/zh-hans/docs/developer-guide/plugin_integration_test_framework.md
+++ b/site/content/zh-hans/docs/developer-guide/plugin_integration_test_framework.md
@@ -9,7 +9,8 @@ title: 插件集成测试框架
 1. 运行 `make build-test-so` 构建 Go 插件。
 2. 运行 `go test -v ./tests/integration -run TestPluginXX` 来运行选定的测试。
 
-测试框架将启动 Envoy 来运行 Go 插件。Envoy 的 stdout/stderr 输出内容可以在 `./test-envoy/$test_name` 中找到。
+测试框架将启动 Envoy 来运行 Go 插件。Envoy 的 stdout/stderr 输出内容可以在 `$test_dir/test-envoy/$test_name` 中找到。
+`$test_dir` 是测试文件所在的目录，在此处指 `./tests/integration`。
 
 一些测试需要第三方服务。您可以通过在 `./tests/integration/testdata/services` 下运行 `docker-compose up $service` 来启动它们。
 


### PR DESCRIPTION
This cause unusablity when using the framework outside this project.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>