### PR TITLE
drop unneccessary git config

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -40,7 +40,7 @@ build-test-so:
 		-w /go/src/${PROJECT_NAME}/api \
 		-e GOPROXY \
 		${BUILD_IMAGE} \
-		bash -c "git config --global --add safe.directory '*' && make build-test-so-local"
+		make build-test-so-local
 
 .PHONY: integration-test
 integration-test:

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -40,7 +40,7 @@ build-test-so:
 	docker run --rm ${MOUNT_GOMOD_CACHE} -v ${PROJECT_ROOT}:/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME}/plugins \
 		-e GOPROXY \
 		${BUILD_IMAGE} \
-		bash -c "git config --global --add safe.directory '*' && make build-test-so-local"
+		make build-test-so-local
 
 .PHONY: start-service
 start-service:
@@ -70,7 +70,7 @@ build-so:
 	docker run --rm ${MOUNT_GOMOD_CACHE} -v ${PROJECT_ROOT}:/go/src/${PROJECT_NAME} -w /go/src/${PROJECT_NAME}/plugins \
 		-e GOPROXY \
 		${BUILD_IMAGE} \
-		bash -c "git config --global --add safe.directory '*' && make build-so-local"
+		make build-so-local
 
 .PHONY: run-demo
 run-demo:


### PR DESCRIPTION
We introduce this configuration previously because the go.mod is at the root. But it's not true anymore.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>