### PR TITLE
controller: add option to disable native plugin

### DIFF
--- a/api/pkg/plugins/plugins.go
+++ b/api/pkg/plugins/plugins.go
@@ -135,6 +135,12 @@ func IterateHttpPlugin(f func(key string, value Plugin) bool) {
 	}
 }
 
+// This method should be called at startup. There will be race if it's called during runtime.
+func DisableHttpPlugin(name string) {
+	delete(httpPlugins, name)
+	delete(httpPluginTypes, name)
+}
+
 type PluginConfigParser struct {
 	GoPlugin
 }

--- a/controller/config/config.default.yaml
+++ b/controller/config/config.default.yaml
@@ -1,8 +1,16 @@
+# This file lists all HTNN controller's configuration and their default value.
+
+
 # If this is set to true, support for Kubernetes gateway-api will be enabled.
 # In addition to this being enabled, the gateway-api CRDs need to be installed.
 enable_gateway_api: true
-# enable embedded mode so that HTNN won't check the annotation of the target resource.
+# Enable embedded mode so that HTNN won't check the annotation of the target resource.
 enable_embedded_mode: true
+# Enable Native plugin. Sometimes we may need to disable all native plugins, because:
+# 1. Only want to use Go plugins
+# 2. A custom Envoy is used and it doesn't support all Envoy's http filters as the default
+# open source one.
+enable_native_plugin: true
 envoy:
   # Should match the Go shared library put in the data plane image
   go_so_path: /etc/libgolang.so

--- a/controller/internal/config/config_test.go
+++ b/controller/internal/config/config_test.go
@@ -27,6 +27,7 @@ func TestInit(t *testing.T) {
 	// Check default values
 	assert.Equal(t, true, EnableGatewayAPI())
 	assert.Equal(t, true, EnableEmbeddedMode())
+	assert.Equal(t, true, EnableNativePlugin())
 	assert.Equal(t, "/etc/libgolang.so", GoSoPath())
 	assert.Equal(t, "istio-system", RootNamespace())
 
@@ -36,6 +37,7 @@ func TestInit(t *testing.T) {
 
 	assert.Equal(t, false, EnableGatewayAPI())
 	assert.Equal(t, false, EnableEmbeddedMode())
+	assert.Equal(t, false, EnableNativePlugin())
 	assert.Equal(t, "/usr/local/golang.so", GoSoPath())
 	assert.Equal(t, "htnn", RootNamespace())
 }

--- a/controller/internal/config/testdata/config.yaml
+++ b/controller/internal/config/testdata/config.yaml
@@ -1,6 +1,7 @@
 # Remember to update the config/config.default.yaml after adding a new item
 enable_gateway_api: false
 enable_embedded_mode: false
+enable_native_plugin: false
 envoy:
   go_so_path: /usr/local/golang.so
 istio:

--- a/controller/tests/integration/controller/httpfilterpolicy_controller_test.go
+++ b/controller/tests/integration/controller/httpfilterpolicy_controller_test.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ import (
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"mosn.io/htnn/controller/internal/config"
 	"mosn.io/htnn/controller/internal/model"
 	"mosn.io/htnn/controller/internal/translation"
 	"mosn.io/htnn/controller/tests/integration/helper"
@@ -1067,6 +1069,85 @@ var _ = Describe("HTTPFilterPolicy controller", func() {
 				cond := policy.Status.Conditions[0]
 				return cond.Reason == string(gwapiv1a2.PolicyReasonTargetNotFound)
 			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When disabling native plugins", func() {
+		BeforeEach(func() {
+			// use env to set the conf
+			os.Setenv("HTNN_ENABLE_NATIVE_PLUGIN", "false")
+			config.Init()
+
+			var httproutes gwapiv1b1.HTTPRouteList
+			if err := k8sClient.List(ctx, &httproutes); err == nil {
+				for _, e := range httproutes.Items {
+					pkg.DeleteK8sResource(ctx, k8sClient, &e)
+				}
+			}
+
+			var gateways gwapiv1b1.GatewayList
+			if err := k8sClient.List(ctx, &gateways); err == nil {
+				for _, e := range gateways.Items {
+					pkg.DeleteK8sResource(ctx, k8sClient, &e)
+				}
+			}
+
+			var policies mosniov1.HTTPFilterPolicyList
+			if err := k8sClient.List(ctx, &policies); err == nil {
+				for _, e := range policies.Items {
+					pkg.DeleteK8sResource(ctx, k8sClient, &e)
+				}
+			}
+
+			input := []map[string]interface{}{}
+			mustReadHTTPFilterPolicy("default_gwapi", &input)
+
+			for _, in := range input {
+				obj := pkg.MapToObj(in)
+				Expect(k8sClient.Create(ctx, obj)).Should(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			os.Setenv("HTNN_ENABLE_NATIVE_PLUGIN", "")
+			config.Init()
+		})
+
+		It("should not produce correndsponding filters", func() {
+			ctx := context.Background()
+			input := []map[string]interface{}{}
+			mustReadHTTPFilterPolicy("native_plugin", &input)
+			for _, in := range input {
+				obj := pkg.MapToObj(in)
+				Expect(k8sClient.Create(ctx, obj)).Should(Succeed())
+			}
+
+			var envoyfilters istiov1a3.EnvoyFilterList
+			Eventually(func() bool {
+				if err := k8sClient.List(ctx, &envoyfilters); err != nil {
+					return false
+				}
+				return len(envoyfilters.Items) == 2
+			}, timeout, interval).Should(BeTrue())
+
+			for _, ef := range envoyfilters.Items {
+				Expect(ef.Namespace).To(Equal("istio-system"))
+				if ef.Name == "htnn-h-default.local" {
+					Expect(len(ef.Spec.ConfigPatches)).To(Equal(1))
+					cp := ef.Spec.ConfigPatches[0]
+					filters := cp.Patch.Value.AsMap()["typed_per_filter_config"].(map[string]interface{})
+					Expect(filters["htnn.filters.http.golang"]).NotTo(BeNil())
+					Expect(filters["htnn.filters.http.localRatelimit"]).To(BeNil())
+				} else {
+					Expect(ef.Name).To(Equal("htnn-http-filter"))
+					cps := ef.Spec.ConfigPatches
+					for _, cp := range cps {
+						if cp.ApplyTo == istioapi.EnvoyFilter_HTTP_FILTER {
+							Expect(cp.Patch.Value.AsMap()["name"]).To(Equal("htnn.filters.http.golang"))
+						}
+					}
+				}
+			}
 		})
 	})
 

--- a/controller/tests/integration/controller/suite_test.go
+++ b/controller/tests/integration/controller/suite_test.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -116,7 +115,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// use env to set the conf
-	os.Setenv("HTNN_ENABLE_GATEWAY_API", "true")
 	config.Init()
 
 	unsafeDisableDeepCopy := true

--- a/controller/tests/integration/controller/testdata/httpfilterpolicy/native_plugin.yml
+++ b/controller/tests/integration/controller/testdata/httpfilterpolicy/native_plugin.yml
@@ -1,0 +1,49 @@
+- apiVersion: htnn.mosn.io/v1
+  kind: HTTPFilterPolicy
+  metadata:
+    name: policy
+    namespace: default
+  spec:
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hr
+    filters:
+      demo:
+        config:
+          hostName: goldfish
+      localRatelimit:
+        config:
+          statPrefix: http_local_rate_limiter
+          tokenBucket:
+            max_tokens: 10000
+            tokens_per_fill: 1000
+            fillInterval: 1s
+          filter_enabled:
+            default_value:
+              numerator: 100
+              denominator: HUNDRED
+          filter_enforced:
+            default_value:
+              numerator: 100
+              denominator: HUNDRED
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: hr
+    namespace: default
+  spec:
+    parentRefs:
+    - name: default
+      sectionName: default
+      port: 8888
+    hostnames:
+      - default.local
+    rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: default
+        port: 8000


### PR DESCRIPTION
Sometimes we may need to disable all native plugins, because:
1. Only want to use Go plugins
2. A custom Envoy is used and it doesn't support all Envoy's http filters as the default open source one.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>