### PR TITLE
change /controller's dependabot rule to be equal others

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/controller"
     schedule:
-      interval: "daily"
-    # Limit number of open PRs to 0 so that we only get security updates
-    # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
-    # We don't upgrade the controller dependency aggressively to reduce the conflict with the istio release.
-    open-pull-requests-limit: 0
+      interval: "weekly"
     ignore:
       - dependency-name: "mosn.io/htnn/*"
       # the Envoy lib need to be fit with the Envoy we use. So let's disable auto-updates.


### PR DESCRIPTION
Only get security updates for a single module is meaningless because other modules may already update a newer dependency. So better to follow other modules' style.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>