### PR TITLE
add ability to run integration test with custom image

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -42,6 +42,7 @@ build-test-so:
 		${BUILD_IMAGE} \
 		bash -c "git config --global --add safe.directory '*' && make build-test-so-local"
 
+# The data plane image used in the integration test can be controlled via env var HTNN_DATA_PLANE_INTEGRATION_TEST_IMAGE
 .PHONY: integration-test
 integration-test:
 	test -d /tmp/htnn_coverage && rm -rf /tmp/htnn_coverage || true

--- a/api/plugins/tests/integration/data_plane/data_plane.go
+++ b/api/plugins/tests/integration/data_plane/data_plane.go
@@ -145,6 +145,12 @@ func StartDataPlane(t *testing.T, opt *Option) (*DataPlane, error) {
 	// Use docker inspect --format='{{index .RepoDigests 0}}' envoyproxy/envoy:contrib-v1.29.4
 	// to get the sha256 ID
 	image := "envoyproxy/envoy@sha256:490f58e109735df4326bac2736ed41e062ce541d3851d634ccbf24552e5b4ce5"
+
+	specifiedImage := os.Getenv("HTNN_DATA_PLANE_INTEGRATION_TEST_IMAGE")
+	if specifiedImage != "" {
+		image = specifiedImage
+	}
+
 	b, err := exec.Command("docker", "images", image).Output()
 	if err != nil {
 		return nil, err

--- a/examples/dev_your_plugin/Makefile
+++ b/examples/dev_your_plugin/Makefile
@@ -105,6 +105,7 @@ build-test-so:
 # you can remove the `go.work` and run `make integration-test`, or copy this module to a directory
 # which doesn't have `go.work` in its ancestors.
 .PHONY: integration-test
+# The data plane image used in the integration test can be controlled via env var HTNN_DATA_PLANE_INTEGRATION_TEST_IMAGE
 integration-test: build-test-so
 	test -d /tmp/htnn_coverage && rm -rf /tmp/htnn_coverage || true
 	go test -v ./tests/integration/...

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -50,6 +50,7 @@ start-service:
 stop-service:
 	cd ./tests/integration/testdata/services && docker-compose down
 
+# The data plane image used in the integration test can be controlled via env var HTNN_DATA_PLANE_INTEGRATION_TEST_IMAGE
 .PHONY: integration-test
 integration-test:
 	test -d /tmp/htnn_coverage && rm -rf /tmp/htnn_coverage || true


### PR DESCRIPTION
For e2e test, we just need to run `istioctl manifest` or something else to change the images used by istio.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>