### PR TITLE
e2e: don't hijack istio's own webhook

### DIFF
--- a/e2e/base/default.yml
+++ b/e2e/base/default.yml
@@ -204,12 +204,9 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-default-validator
+  name: istiod-htnn-validator
   labels:
-    app: istiod
-    istio: istiod
     istio.io/rev: default
-    istio.io/tag: default
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -222,17 +219,13 @@ webhooks:
       port: 443
   failurePolicy: Fail
   matchPolicy: Equivalent
-  name: validation.istio.io
+  name: validation.htnn.mosn.io
   objectSelector:
     matchExpressions:
     - key: istio.io/rev
       operator: DoesNotExist
   rules:
   - apiGroups:
-    - security.istio.io
-    - networking.istio.io
-    - telemetry.istio.io
-    - extensions.istio.io
     - htnn.mosn.io
     apiVersions:
     - '*'
@@ -244,4 +237,4 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10
-# Don't add istio resource after this resource - there's a race that the webhook is updating and causes the validation to fail
+# Don't add htnn resource after this resource - there's a race that the webhook is updating and causes the validation to fail


### PR DESCRIPTION
The cabundle injector injects the webhook by the label, so we can solve this by providing the label.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>