### PR TITLE
get rid of submodule from CI & docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
         working-directory: ./api
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -78,8 +76,6 @@ jobs:
         working-directory: ./types
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -106,8 +102,6 @@ jobs:
         working-directory: ./plugins
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -132,8 +126,6 @@ jobs:
         working-directory: ./plugins
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -176,8 +168,6 @@ jobs:
         working-directory: ./controller
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -215,8 +205,6 @@ jobs:
     if: always()
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
     - name: Download artifact
       uses: actions/download-artifact@v4
     - name: Upload to codecov
@@ -239,8 +227,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -265,8 +251,6 @@ jobs:
         working-directory: ./e2e
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -19,6 +19,6 @@ To upgrade Istio, please follow the steps below:
 
 1. Discuss the impact of the upgrade. For example, is there any break change, do we need to upgrade K8S, etc.
 2. Update the base image used in the integration / e2e tests.
-3. Update the ISTIO_VERSION we define in the Makefile and the submodule under `./external`.
+3. Update the ISTIO_VERSION we define in the Makefile.
 4. Update the versions of istio, envoy and go-control-plane package in the `go.mod` and `go.sum`.
 5. Update the link `/envoy/v1.xx.y/configuration/` in the doc to the new Envoy version.


### PR DESCRIPTION
The commit https://github.com/mosn/htnn/commit/ae4829cbf34cada3ce024f039b8cacad129ae962 doesn't get rid of them completely.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>