### PR TITLE
detect shared library to avoid creating an empty libgolang directory

### DIFF
--- a/api/plugins/tests/integration/data_plane/data_plane_test.go
+++ b/api/plugins/tests/integration/data_plane/data_plane_test.go
@@ -1,0 +1,30 @@
+// Copyright The HTNN Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data_plane
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBadSharedLibraryDetection(t *testing.T) {
+	d, _ := os.MkdirTemp("", "data_plane_test")
+	os.Chdir(d)
+	_, err := StartDataPlane(t, nil)
+	assert.True(t, strings.HasSuffix(err.Error(), "no such file or directory"))
+}


### PR DESCRIPTION
Previously, when make integration-test is called without building the shared library, an empty directory is created, which will cause the new so created inside this directory, and cause the next `make integration-test` to fail.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>