### PR TITLE
don't run the `init` function in the plugins' package

### DIFF
--- a/patch/istio/1.21/20240410-htnn-go-mod.patch
+++ b/patch/istio/1.21/20240410-htnn-go-mod.patch
@@ -25,3 +25,15 @@ index e7f308e890..def9507093 100644
  require (
  	cloud.google.com/go/compute/metadata v0.2.3
  	cloud.google.com/go/logging v1.9.0
+diff --git a/pilot/pkg/config/htnn/types.go b/pilot/pkg/config/htnn/types.go
+new file mode 100644
+index 0000000000..8d39ede5b0
+--- /dev/null
++++ b/pilot/pkg/config/htnn/types.go
+@@ -0,0 +1,6 @@
++package htnn
++
++import (
++   _ "mosn.io/htnn/types/plugins"    // register plugin types
++   _ "mosn.io/htnn/types/registries" // register registry types
++)

--- a/types/apis/v1/validation.go
+++ b/types/apis/v1/validation.go
@@ -25,8 +25,6 @@ import (
 	"mosn.io/htnn/api/pkg/plugins"
 	"mosn.io/htnn/types/pkg/proto"
 	"mosn.io/htnn/types/pkg/registry"
-	_ "mosn.io/htnn/types/plugins"    // register plugin types
-	_ "mosn.io/htnn/types/registries" // register registry types
 )
 
 // ValidateHTTPFilterPolicy validates HTTPFilterPolicy.

--- a/types/apis/v1/validation_test.go
+++ b/types/apis/v1/validation_test.go
@@ -26,6 +26,8 @@ import (
 	gwapiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"mosn.io/htnn/api/pkg/plugins"
+	_ "mosn.io/htnn/types/plugins"    // register plugin types
+	_ "mosn.io/htnn/types/registries" // register registry types
 )
 
 func TestValidateHTTPFilterPolicy(t *testing.T) {


### PR DESCRIPTION
Now there will not be logs like `register plugin xxx` when running unit tests.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>