### PR TITLE
chore: remove obsolete docker compose version

### DIFF
--- a/controller/tests/testdata/services/docker-compose.yml
+++ b/controller/tests/testdata/services/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   nacos:
     image: nacos/nacos-server:v1.4.6-slim

--- a/plugins/tests/integration/testdata/services/docker-compose.yml
+++ b/plugins/tests/integration/testdata/services/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   # names in alphabetical order
   hydra:

--- a/site/docker-compose.yaml
+++ b/site/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
   site:


### PR DESCRIPTION
See https://news.ycombinator.com/item?id=40196989
This suppresses a warning when we run docker-compose.