### PR TITLE
ci: fix broken website link check

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         # ./tmp is cached for htmltest
         path: |
-          ./site/bin
           ./site/tmp
         key: ${{ runner.os }}-${{ hashFiles('./Makefile') }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ e2e/log
 .idea
 # helm charts
 manifests/charts/**/*.tgz
-.idea

--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,9 @@ fix-cjk: dev-tools
 .PHONY: lint-website
 lint-website: $(LOCALBIN)
 	test -x $(LOCALBIN)/htmltest || GOBIN=$(LOCALBIN) go install github.com/wjdp/htmltest@v0.17.0
-	$(LOCALBIN)/htmltest --conf ./.htmltest.yml ./public | grep  -E '(target does not exist|Non-OK status: 404)' \
-		&& exit 1 || true
+	cd ./site && $(LOCALBIN)/htmltest --conf ./.htmltest.yml ./public > /tmp/htmltest.log || true
+	@# ignore 'lookup htnn.mosn.io: no such host' error for now
+	test -f /tmp/htmltest.log && (grep -E '(target does not exist|Non-OK status: 404)' /tmp/htmltest.log && exit 1 || true)
 
 .PHONY: lint-remain
 lint-remain:


### PR DESCRIPTION
It was broken since https://github.com/mosn/htnn/commit/6109acdea2f10eff86632c54baa3c97573156edf
Signed-off-by: spacewander <spacewanderlzx@gmail.com>