### PR TITLE
ci: don't use deprecated docker-compose

### DIFF
--- a/api/plugins/tests/integration/helper/helper.go
+++ b/api/plugins/tests/integration/helper/helper.go
@@ -34,7 +34,7 @@ func WriteTempFile(s string) *os.File {
 func WaitServiceUp(t *testing.T, port string, service string) {
 	msg := ""
 	if service != "" {
-		msg = fmt.Sprintf("Service is unavailable. Please run `docker-compose up %s` under ./plugins/tests/integration/testdata/services and ensure it is started", service)
+		msg = fmt.Sprintf("Service is unavailable. Please run `docker compose up %s` under ./plugins/tests/integration/testdata/services and ensure it is started", service)
 	}
 	require.Eventually(t, func() bool {
 		c, err := net.DialTimeout("tcp", port, 10*time.Millisecond)

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -110,8 +110,8 @@ $(ENVTEST): $(LOCALBIN)
 
 .PHONY: start-controller-service
 start-controller-service:
-	cd ./tests/testdata/services && docker-compose up -d
+	cd ./tests/testdata/services && docker compose up -d
 
 .PHONY: stop-controller-service
 stop-controller-service:
-	cd ./tests/testdata/services && docker-compose down
+	cd ./tests/testdata/services && docker compose down

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -44,11 +44,11 @@ build-test-so:
 
 .PHONY: start-service
 start-service:
-	cd ./tests/integration/testdata/services && docker-compose up -d --build
+	cd ./tests/integration/testdata/services && docker compose up -d --build
 
 .PHONY: stop-service
 stop-service:
-	cd ./tests/integration/testdata/services && docker-compose down
+	cd ./tests/integration/testdata/services && docker compose down
 
 # The data plane image used in the integration test can be controlled via env var PROXY_IMAGE
 .PHONY: integration-test

--- a/site/Makefile
+++ b/site/Makefile
@@ -16,15 +16,15 @@ include ../common.mk
 
 .PHONY: build
 build:
-	docker-compose build
+	docker compose build
 
 .PHONY: up
 up:
-	docker-compose up
+	docker compose up
 
 .PHONY: clean
 clean:
-	docker-compose rm
+	docker compose rm
 
 .PHONY: publish
 # The generated files will be under ./public

--- a/site/content/en/docs/developer-guide/plugin_integration_test_framework.md
+++ b/site/content/en/docs/developer-guide/plugin_integration_test_framework.md
@@ -12,7 +12,7 @@ Assumed you are at the `./plugins`:
 The test framework will start Envoy to run the Go plugins. The stdout/stderr of the Envoy can be found in `$test_dir/test-envoy/$test_name`.
 The `$test_dir` is where the test files locate, which is `./tests/integration` in this case.
 
-Some tests require third-party services. You can start them by running `docker-compose up $service` under `./tests/integration/testdata/services`.
+Some tests require third-party services. You can start them by running `docker compose up $service` under `./tests/integration/testdata/services`.
 
 By default, the test framework starts Envoy using the image `envoyproxy/envoy`. You can specify a different image by setting the `PROXY_IMAGE` environment variable. For example, `PROXY_IMAGE=envoyproxy/envoy:contrib-v1.29.4 go test -v ./tests/integration/ -run TestLimitCountRedis` will use the image `envoyproxy/envoy:contrib-v1.29.4`.
 

--- a/site/content/zh-hans/docs/developer-guide/plugin_integration_test_framework.md
+++ b/site/content/zh-hans/docs/developer-guide/plugin_integration_test_framework.md
@@ -12,7 +12,7 @@ title: 插件集成测试框架
 测试框架将启动 Envoy 来运行 Go 插件。Envoy 的 stdout/stderr 输出内容可以在 `$test_dir/test-envoy/$test_name` 中找到。
 `$test_dir` 是测试文件所在的目录，在此处指 `./tests/integration`。
 
-一些测试需要第三方服务。您可以通过在 `./tests/integration/testdata/services` 下运行 `docker-compose up $service` 来启动它们。
+一些测试需要第三方服务。您可以通过在 `./tests/integration/testdata/services` 下运行 `docker compose up $service` 来启动它们。
 
 默认情况下，测试框架通过镜像 `envoyproxy/envoy` 启动 Envoy。你可以通过设置环境变量 `PROXY_IMAGE` 来指定其他镜像。例如，`PROXY_IMAGE=envoyproxy/envoy:contrib-v1.29.4 go test -v ./tests/integration/ -run TestLimitCountRedis` 将使用 `envoyproxy/envoy:contrib-v1.29.4` 镜像。
 


### PR DESCRIPTION
GitHub Action no longer supports this command.
See https://github.com/orgs/community/discussions/116610

This fixes the broken CI.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>