### PR TITLE
e2e: solve the flaky consumer test

### DIFF
--- a/e2e/htnn_controller_values.yaml
+++ b/e2e/htnn_controller_values.yaml
@@ -22,6 +22,7 @@ pilot:
 global:
   proxy:
     image: "htnn/gateway:e2e"
+    componentLogLevel: "config:debug,golang:debug"
   imagePullPolicy: IfNotPresent
   logging:
     level: "htnn:debug"

--- a/e2e/pkg/suite/suite.go
+++ b/e2e/pkg/suite/suite.go
@@ -106,7 +106,7 @@ func (suite *Suite) Run(t *testing.T) {
 			}
 			// TODO: find a signal to indicate that it's OK to test.
 			// EnvoyFilter is created doesn't mean that the RDS takes effects in Envoy.
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(600 * time.Millisecond)
 			// TODO: configure Istio to push aggressively
 
 			t.Logf("Run test %q at %v", test.Name, time.Now())


### PR DESCRIPTION
<!--
Please change the [issue] below to the number of issue which is addressed by this
pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
If there is no issue, please remove this prompt.
-->

Fix https://github.com/mosn/htnn/issues/659

<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
