### PR TITLE
fix: should reset pluginState and other fields

### DIFF
--- a/api/internal/consumer/mock.go
+++ b/api/internal/consumer/mock.go
@@ -74,3 +74,14 @@ func (p *filterPlugin) Factory() api.FilterFactory {
 func (p *filterPlugin) Config() api.PluginConfig {
 	return &Config{}
 }
+
+type MockConsumer struct {
+}
+
+func (c *MockConsumer) Name() string {
+	return "mock"
+}
+
+func (c *MockConsumer) PluginConfig(_ string) api.PluginConsumerConfig {
+	return &ConsumerConfig{}
+}

--- a/api/pkg/filtermanager/api_impl.go
+++ b/api/pkg/filtermanager/api_impl.go
@@ -160,7 +160,10 @@ func (cb *filterManagerCallbackHandler) Reset() {
 	// We don't reset namespace, as filterManager will only be reused in the same route,
 	// which must have the same namespace.
 	cb.consumer = nil
+	cb.pluginState = nil
 	cb.streamInfo = nil
+	cb.logArgNames = ""
+	cb.logArgs = nil
 
 	cb.cacheLock.Unlock()
 }

--- a/api/pkg/filtermanager/api_impl_test.go
+++ b/api/pkg/filtermanager/api_impl_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 
+	"mosn.io/htnn/api/internal/consumer"
 	"mosn.io/htnn/api/pkg/filtermanager/api"
 	"mosn.io/htnn/api/pkg/filtermanager/model"
 	"mosn.io/htnn/api/plugins/tests/pkg/envoy"
@@ -232,4 +233,27 @@ func TestLogWithArgs(t *testing.T) {
 		assert.Equal(t, "testLog: out: %s, k1: %v, k2: %v", fmtStr[level+"f"])
 		assert.Equal(t, []any{0, 1, 2}, fmtArgs[level+"f"])
 	}
+}
+
+func TestReset(t *testing.T) {
+	cb := &filterManagerCallbackHandler{
+		FilterCallbackHandler: envoy.NewCAPIFilterCallbackHandler(),
+	}
+	cb.SetConsumer(&consumer.MockConsumer{})
+	cb.PluginState()
+	cb.StreamInfo()
+	cb.WithLogArg("k", "v")
+
+	assert.NotNil(t, cb.consumer)
+	assert.NotNil(t, cb.pluginState)
+	assert.NotNil(t, cb.streamInfo)
+	assert.NotEqual(t, "", cb.logArgNames)
+	assert.NotNil(t, cb.logArgs)
+
+	cb.Reset()
+	assert.Nil(t, cb.consumer)
+	assert.Nil(t, cb.pluginState)
+	assert.Nil(t, cb.streamInfo)
+	assert.Equal(t, "", cb.logArgNames)
+	assert.Nil(t, cb.logArgs)
 }


### PR DESCRIPTION
Otherwise, the recorded exec time is incorrect after recycling.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
Please change the [issue] below to the number of issue which is addressed by this
pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
If there is no issue, please remove this prompt.
-->

<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
