### PR TITLE
improve the UX of consul test

### DIFF
--- a/controller/registries/consul/config_test.go
+++ b/controller/registries/consul/config_test.go
@@ -373,6 +373,7 @@ func TestReload(t *testing.T) {
 	patches.ApplyPrivateMethod(reflect.TypeOf(reg), "unsubscribe", func(_ *Consul, serviceName string) error {
 		return nil
 	})
+	defer patches.Reset()
 
 	err := reg.Reload(&consul.Config{})
 
@@ -381,8 +382,6 @@ func TestReload(t *testing.T) {
 	assert.Contains(t, reg.watchingServices, consulService{"test-service", "new-datacenter"})
 
 	reg.removeService(service)
-
-	patches.Reset()
 }
 
 func TestSubscribe(t *testing.T) {

--- a/controller/tests/testdata/services/docker-compose.yml
+++ b/controller/tests/testdata/services/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: nacos/nacos-server:v1.4.6-slim
     env_file:
       - env/nacos.env
+    # all services should have this restart policy, so that we don't need to
+    # restart them manually after the dev machine reboots
     restart: unless-stopped
     ports:
       - "8848:8848"
@@ -19,6 +21,7 @@ services:
       service:
   consul:
     image: docker.m.daocloud.io/library/consul:1.15.4
+    restart: unless-stopped
     ports:
       - "8500:8500"
       - "8600:8600"
@@ -27,6 +30,7 @@ services:
       service:
   consul1:
     image: docker.m.daocloud.io/library/consul:1.15.4
+    restart: unless-stopped
     ports:
       - "8501:8500"
       - "8601:8600"


### PR DESCRIPTION
The ut will crash with `SIGBUS: bus error` on Mac. Use `defer` solve
this problem.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>