### PR TITLE
consumer: allow specifying different name when writing to k8s

### DIFF
--- a/controller/tests/integration/controller/testdata/consumer/consumer_name_conflict.yml
+++ b/controller/tests/integration/controller/testdata/consumer/consumer_name_conflict.yml
@@ -1,0 +1,21 @@
+- apiVersion: htnn.mosn.io/v1
+  kind: Consumer
+  metadata:
+    name: spacewander
+    namespace: default
+  spec:
+    auth:
+      keyAuth:
+        config:
+          key: xx
+- apiVersion: htnn.mosn.io/v1
+  kind: Consumer
+  metadata:
+    name: spacewander2
+    namespace: default
+  spec:
+    name: spacewander
+    auth:
+      keyAuth:
+        config:
+          key: xx

--- a/e2e/tests/consumer.go
+++ b/e2e/tests/consumer.go
@@ -62,7 +62,7 @@ func init() {
 
 			c := suite.K8sClient()
 			ctx := context.Background()
-			nsName := types.NamespacedName{Name: "morty", Namespace: k8s.DefaultNamespace}
+			nsName := types.NamespacedName{Name: "summer", Namespace: k8s.DefaultNamespace}
 			var consumer mosniov1.Consumer
 			err = c.Get(ctx, nsName, &consumer)
 			require.NoError(t, err)

--- a/e2e/tests/consumer.yml
+++ b/e2e/tests/consumer.yml
@@ -35,8 +35,9 @@ spec:
 apiVersion: htnn.mosn.io/v1
 kind: Consumer
 metadata:
-  name: morty
+  name: summer
 spec:
+  name: morty # the name specific in the spec is prior to the metadata name
   auth:
     keyAuth:
       config:

--- a/manifests/charts/htnn-controller/templates/crds/htnn.mosn.io_consumers.yaml
+++ b/manifests/charts/htnn-controller/templates/crds/htnn.mosn.io_consumers.yaml
@@ -66,6 +66,11 @@ spec:
                   type: object
                 description: Filters is a map of filter names to filter configurations.
                 type: object
+              name:
+                description: |-
+                  Name is the name of consumer, which is used in the data plane matching.
+                  If this field is not set, the name of the consumer CustomResource will be used.
+                type: string
             required:
             - auth
             type: object

--- a/types/apis/v1/consumer_types.go
+++ b/types/apis/v1/consumer_types.go
@@ -45,6 +45,12 @@ type ConsumerSpec struct {
 	//
 	// +optional
 	Filters map[string]Plugin `json:"filters,omitempty"`
+
+	// Name is the name of consumer, which is used in the data plane matching.
+	// If this field is not set, the name of the consumer CustomResource will be used.
+	//
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // ConsumerStatus defines the observed state of Consumer


### PR DESCRIPTION
This make it possible to contain special info in the name of k8s custom resource, which is different from the name used in the request matching. This feature is useful with server side filter.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>
