### PR TITLE
test: ensure the correct EnvoyFilter is kept & improve Nacos config test

### DIFF
--- a/controller/registries/nacos/v1/config.go
+++ b/controller/registries/nacos/v1/config.go
@@ -174,6 +174,7 @@ func NewClient(config *nacos.Config) (*NacosClient, error) {
 		),
 	}
 
+	fmt.Printf("AA %+v %+v\n", cc, sc)
 	namingClient, err := clients.NewNamingClient(vo.NacosClientParam{
 		ClientConfig:  cc,
 		ServerConfigs: sc,

--- a/controller/registries/nacos/v1/config_test.go
+++ b/controller/registries/nacos/v1/config_test.go
@@ -29,6 +29,19 @@ import (
 
 func TestNewClient(t *testing.T) {
 	config := &nacos.Config{
+		ServerUrl: "http://127.0.0.1:9999999",
+	}
+	_, err := NewClient(config)
+	assert.ErrorContains(t, err, "can not create naming client")
+
+	config = &nacos.Config{
+		ServerUrl: "::::::::::::",
+	}
+
+	_, err = NewClient(config)
+	assert.ErrorContains(t, err, "invalid server url")
+
+	config = &nacos.Config{
 		ServerUrl: "http://127.0.0.1:8848",
 		Version:   "v1",
 	}
@@ -43,20 +56,8 @@ func TestNewClient(t *testing.T) {
 	patches.ApplyFunc(clients.NewNamingClient, func(param vo.NacosClientParam) (naming_client.INamingClient, error) {
 		return nil, nil
 	})
-	_, err := NewClient(config)
+	_, err = NewClient(config)
 	assert.Nil(t, err)
 
 	patches.Reset()
-
-	config = &nacos.Config{}
-	_, err = NewClient(config)
-	assert.Error(t, err)
-
-	config = &nacos.Config{
-		ServerUrl: "::::::::::::",
-	}
-
-	_, err = NewClient(config)
-	assert.Error(t, err)
-
 }

--- a/controller/tests/integration/controller/consumer_controller_test.go
+++ b/controller/tests/integration/controller/consumer_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Consumer controller", func() {
 					return false
 				}
 				for _, item := range envoyfilters.Items {
-					if item.Name == "htnn-consumer" {
+					if item.Name == "htnn-consumer" && item.Namespace == "istio-system" {
 						ef = item
 						return true
 					}
@@ -114,7 +114,6 @@ var _ = Describe("Consumer controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(ef.Namespace).To(Equal("istio-system"))
 			Expect(len(ef.Spec.ConfigPatches)).To(Equal(2))
 			cp := ef.Spec.ConfigPatches[0]
 			Expect(cp.ApplyTo).To(Equal(istioapi.EnvoyFilter_EXTENSION_CONFIG))


### PR DESCRIPTION
<!--
Please change the [issue] below to the number of issue which is addressed by this
pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
If there is no issue, please remove this prompt.
-->

Fix #720 

<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
