### PR TITLE
fix: the plugin order sent from controller may be wrong

### DIFF
--- a/api/pkg/plugins/plugins.go
+++ b/api/pkg/plugins/plugins.go
@@ -202,8 +202,8 @@ func ComparePluginOrder(a, b string) bool {
 }
 
 func ComparePluginOrderInt(a, b string) int {
-	pa := plugins[a]
-	pb := plugins[b]
+	pa := pluginTypes[a]
+	pb := pluginTypes[b]
 	if pa == nil || pb == nil {
 		// The caller should guarantee the a, b are valid plugin name, so this case only happens
 		// in test.

--- a/controller/internal/translation/testdata/translation/virtualservice_subpolicies.out.yml
+++ b/controller/internal/translation/testdata/translation/virtualservice_subpolicies.out.yml
@@ -28,14 +28,14 @@
                     value:
                       plugins:
                       - config:
+                          average: 1
+                        name: limitReq
+                      - config:
                           pet: goldfish
                         name: animal
                       - config:
                           hostName: John
                         name: demo
-                      - config:
-                          average: 1
-                        name: limitReq
     - applyTo: HTTP_ROUTE
       match:
         routeConfiguration:
@@ -57,16 +57,16 @@
                       namespace: default
                       plugins:
                       - config:
-                          pet: fish
-                        name: animal
-                      - config:
-                          hostName: John
-                        name: demo
-                      - config:
                           keys:
                           - name: Authorization
                         name: keyAuth
                       - config:
                           average: 1
                         name: limitReq
+                      - config:
+                          pet: fish
+                        name: animal
+                      - config:
+                          hostName: John
+                        name: demo
   status: {}


### PR DESCRIPTION
<!--
Please change the [issue] below to the number of issue which is addressed by this
pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
If there is no issue, please remove this prompt.
-->


<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
