### PR TITLE
Update bootstrap.yml to fix host.docker.internal resolve as ip v6 address in docker v4.31.0

### DIFF
--- a/api/plugins/tests/integration/dataplane/bootstrap.yml
+++ b/api/plugins/tests/integration/dataplane/bootstrap.yml
@@ -258,6 +258,7 @@ static_resources:
                 socket_address:
                   address: host.docker.internal
                   port_value: 9999
+      dns_lookup_family: V4_ONLY
 
 admin:
   address:


### PR DESCRIPTION
fix host.docker.internal resolve as ip v6 address in docker v4.31.0, see docker issue[7332](https://github.com/docker/for-mac/issues/7332)
