### PR TITLE
test: improve the config change detection

### DIFF
--- a/api/plugins/tests/integration/controlplane/control_plane.go
+++ b/api/plugins/tests/integration/controlplane/control_plane.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"runtime"
@@ -75,6 +76,15 @@ func NewControlPlane() *ControlPlane {
 		grpcServer:    grpcServer,
 	}
 	return cp
+}
+
+func getRandomString(n int) string {
+	var Letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	result := make([]rune, n)
+	for i := range result {
+		result[i] = Letters[rand.Intn(len(Letters))]
+	}
+	return string(result)
 }
 
 func isWsl() bool {
@@ -179,6 +189,7 @@ func (cp *ControlPlane) UseGoPluginConfig(t *testing.T, config *filtermanager.Fi
 						Domains: []string{"*"},
 						Routes: []*route.Route{
 							{
+								Name: getRandomString(8),
 								Match: &route.RouteMatch{
 									PathSpecifier: &route.RouteMatch_Path{
 										Path: "/detect_if_the_rds_takes_effect",
@@ -195,7 +206,7 @@ func (cp *ControlPlane) UseGoPluginConfig(t *testing.T, config *filtermanager.Fi
 											"fm": {
 												Override: &golang.RouterPlugin_Config{
 													Config: proto.MessageToAny(
-														FilterManagerConfigToTypedStruct(NewPluginConfig(nil))),
+														FilterManagerConfigToTypedStruct(NewSinglePluginConfig("detector", nil))),
 												},
 											},
 										},

--- a/api/plugins/tests/integration/controlplane/control_plane.go
+++ b/api/plugins/tests/integration/controlplane/control_plane.go
@@ -79,10 +79,10 @@ func NewControlPlane() *ControlPlane {
 }
 
 func getRandomString(n int) string {
-	var Letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	result := make([]rune, n)
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	result := make([]byte, n)
 	for i := range result {
-		result[i] = Letters[rand.Intn(len(Letters))]
+		result[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(result)
 }


### PR DESCRIPTION
Fix the flaky test TestFilterManagerEncode.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
Please uncomment and change the [issue] below to the number of issue which is
addressed by this pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
-->

<!--Fix #[issue]-->

<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
