### PR TITLE
fix: add more config validation logic to networkRBAC plugin (#629)

### DIFF
--- a/types/plugins/networkrbac/config.go
+++ b/types/plugins/networkrbac/config.go
@@ -112,6 +112,42 @@ func (conf *CustomConfig) Validate() error {
 		}
 	}
 	// TODO: validate the Action in the other matcher like ExactMatchMap
+
+	// validate ExactMatchMap
+	// Check if exact match configuration exists
+	exactMatchMap := m.GetExactMatchMap()
+	if exactMatchMap != nil {
+		// Get all exact match rules
+		ruleMap := exactMatchMap.GetMap()
+
+		// Loop through each rule
+		for ruleKey, ruleValue := range ruleMap {
+			// Get the action configuration from the rule
+			actionConfig := ruleValue.GetAction().GetTypedConfig()
+			if actionConfig == nil {
+				return fmt.Errorf("rule %s is missing action configuration", ruleKey)
+			}
+
+			// Get the actual configuration value
+			configValue := actionConfig.GetValue()
+			if len(configValue) == 0 {
+				return fmt.Errorf("action configuration is empty for rule %s", ruleKey)
+			}
+
+			// Create a new action object
+			action := &rbacconfig.Action{}
+
+			// Parse the configuration into the action object
+			if err := proto.Unmarshal(configValue, action); err != nil {
+				return fmt.Errorf("failed to parse action configuration for rule %s: %v", ruleKey, err)
+			}
+
+			// Validate if the action configuration is valid
+			if err := action.Validate(); err != nil {
+				return fmt.Errorf("invalid action configuration for rule %s: %v", ruleKey, err)
+			}
+		}
+	}
 	// Another TODO: do it more smartly
 	return nil
 }

--- a/types/plugins/networkrbac/config_test.go
+++ b/types/plugins/networkrbac/config_test.go
@@ -122,10 +122,10 @@ func TestConfig(t *testing.T) {
   }
 }
 			`,
-			err: "invalid Action.Name: value length must be at least 1 runes",
+			err: "IPMatcher action validation failed: invalid Action.Name: value length must be at least 1 runes",
 		},
 		{
-			name: "validate exact match map",
+			name: "validate exactMatchMap action",
 			input: `
 {
   "statPrefix": "network_rbac",
@@ -139,11 +139,12 @@ func TestConfig(t *testing.T) {
       },
       "exactMatchMap": {
         "map": {
-          "rule1": {
+          "127.0.0.1": {
             "action": {
-              "name": "envoy.filters.rbac.action",
+              "name": "",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action"
+                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                "action": "DENY"
               }
             }
           }
@@ -153,7 +154,105 @@ func TestConfig(t *testing.T) {
   }
 }
 			`,
-			err: "action configuration is empty for rule rule1",
+			err: "exactMatchMap action validation failed: invalid Action.Name: value length must be at least 1 runes",
+		},
+		{
+			name: "validate exactMatchMap with valid action",
+			input: `
+{
+  "statPrefix": "network_rbac",
+  "matcher": {
+    "matcherTree": {
+      "input": {
+        "name": "envoy.matching.inputs.source_ip",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.SourceIPInput"
+        }
+      },
+      "exactMatchMap": {
+        "map": {
+          "127.0.0.1": {
+            "action": {
+              "name": "valid.action.name",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                "name": "valid.action.name",
+                "action": "DENY"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+			`,
+			err: "",
+		},
+		{
+			name: "validate prefixMatchMap action",
+			input: `
+{
+  "statPrefix": "network_rbac",
+  "matcher": {
+    "matcherTree": {
+      "input": {
+        "name": "envoy.matching.inputs.source_ip",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.SourceIPInput"
+        }
+      },
+      "prefixMatchMap": {
+        "map": {
+          "127.0.0": {
+            "action": {
+              "name": "",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                "action": "ALLOW"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+			`,
+			err: "prefixMatchMap action validation failed: invalid Action.Name: value length must be at least 1 runes",
+		},
+		{
+			name: "validate prefixMatchMap with valid action",
+			input: `
+{
+  "statPrefix": "network_rbac",
+  "matcher": {
+    "matcherTree": {
+      "input": {
+        "name": "envoy.matching.inputs.source_ip",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.SourceIPInput"
+        }
+      },
+      "prefixMatchMap": {
+        "map": {
+          "127.0.0": {
+            "action": {
+              "name": "valid.action.name",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                "name": "valid.action.name",
+                "action": "ALLOW"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+			`,
+			err: "",
 		},
 	}
 

--- a/types/plugins/networkrbac/config_test.go
+++ b/types/plugins/networkrbac/config_test.go
@@ -124,6 +124,37 @@ func TestConfig(t *testing.T) {
 			`,
 			err: "invalid Action.Name: value length must be at least 1 runes",
 		},
+		{
+			name: "validate exact match map",
+			input: `
+{
+  "statPrefix": "network_rbac",
+  "matcher": {
+    "matcherTree": {
+      "input": {
+        "name": "envoy.matching.inputs.source_ip",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.SourceIPInput"
+        }
+      },
+      "exactMatchMap": {
+        "map": {
+          "rule1": {
+            "action": {
+              "name": "envoy.filters.rbac.action",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+			`,
+			err: "action configuration is empty for rule rule1",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix:

#629 

This pull request adds additional configuration validation to the networkRBAC plugin.

**What’s changed:**

Added validation for matcher: exactMatchMap

**Test:**

Added unit tests in config_test.go to verify invalid configurations are caught

All tests passed via go test ./...


@spacewander
 I would sincerely appreciate any feedback or suggestions you might have. Thank you for reviewing this PR!