### PR TITLE
[feat] an effective way to detect collision in the control plane

### DIFF
--- a/api/pkg/plugins/type.go
+++ b/api/pkg/plugins/type.go
@@ -185,3 +185,7 @@ type ConsumerPlugin interface {
 
 	ConsumerConfig() api.PluginConsumerConfig
 }
+
+type Indexer interface {
+	Index() string
+}

--- a/controller/internal/controller/consumer_controller.go
+++ b/controller/internal/controller/consumer_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mosn.io/htnn/api/pkg/plugins"
 	"sync"
 	"time"
 
@@ -46,14 +47,14 @@ type ConsumerReconciler struct {
 }
 
 type KeyIndexRegistry struct {
-	mu    sync.RWMutex
+	mu    sync.Mutex
 	index map[string]map[string]map[string]string // ns -> plugin -> key -> consumerName
 }
 
 func NewKeyIndexRegistry() *KeyIndexRegistry {
 	return &KeyIndexRegistry{
 		index: make(map[string]map[string]map[string]string),
-		mu:    sync.RWMutex{},
+		mu:    sync.Mutex{},
 	}
 }
 
@@ -204,9 +205,6 @@ func (r *ConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // checkConsumerConflicts Perform full conflict detection and rebuild the index
 func (r *ConsumerReconciler) checkConsumerConflicts(ctx context.Context, state *consumerReconcileState) error {
-	r.keyIndex.mu.Lock()
-	defer r.keyIndex.mu.Unlock()
-
 	// Clear old indexes
 	r.keyIndex.index = make(map[string]map[string]map[string]string)
 
@@ -214,7 +212,8 @@ func (r *ConsumerReconciler) checkConsumerConflicts(ctx context.Context, state *
 	for ns, consumers := range state.namespaceToConsumers {
 		for _, consumer := range consumers {
 			if err := r.indexConsumer(ns, consumer); err != nil {
-				return err
+				log.Error("Conflict detected")
+				consumer.SetAccepted(mosniov1.ReasonInvalid, err.Error())
 			}
 		}
 	}
@@ -223,22 +222,34 @@ func (r *ConsumerReconciler) checkConsumerConflicts(ctx context.Context, state *
 
 // indexConsumer method to use the plugin's Index method
 func (r *ConsumerReconciler) indexConsumer(namespace string, consumer *mosniov1.Consumer) error {
+	r.keyIndex.mu.Lock()
+	defer r.keyIndex.mu.Unlock()
+
+	if consumer == nil || consumer.Spec.Auth == nil {
+		return fmt.Errorf("nil consumer or auth config")
+	}
+
 	for pluginName, plugin := range consumer.Spec.Auth {
-		// Get the plugin from the registry
-		registeredPlugin, exists := pluginRegistry[pluginName]
-		if !exists {
-			return fmt.Errorf("unknown plugin: %s", pluginName)
+
+		p, ok := plugins.LoadPlugin(pluginName).(plugins.Plugin)
+		if !ok {
+			return fmt.Errorf("plugin %s is not for consumer", pluginName)
 		}
 
-		// Create configuration instances through the plugin interface
-		pluginConfig := registeredPlugin.NewConfig()
-		if err := json.Unmarshal(plugin.Config.Raw, pluginConfig); err != nil {
+		// Parse configuration
+		config := p.Config()
+		if err := json.Unmarshal(plugin.Config.Raw, config); err != nil {
 			return fmt.Errorf("invalid config for plugin %s: %w", pluginName, err)
 		}
 
-		key := pluginConfig.Index()
+		// Obtain a unique identifier
+		indexer, ok := config.(plugins.Indexer)
+		if !ok {
+			return fmt.Errorf("plugin %s config does not implement Indexer", pluginName)
+		}
+		key := indexer.Index()
 
-		// Initialize the three-level map if needed
+		// Initialize the index structure
 		if r.keyIndex.index[namespace] == nil {
 			r.keyIndex.index[namespace] = make(map[string]map[string]string)
 		}
@@ -246,31 +257,15 @@ func (r *ConsumerReconciler) indexConsumer(namespace string, consumer *mosniov1.
 			r.keyIndex.index[namespace][pluginName] = make(map[string]string)
 		}
 
-		// Check for collision
+		// collision detection
 		if existing, exists := r.keyIndex.index[namespace][pluginName][key]; exists {
 			return fmt.Errorf(
 				"key conflict in namespace %s: plugin=%s key=%s (already used by %s)",
 				namespace, pluginName, key, existing,
 			)
 		}
+
 		r.keyIndex.index[namespace][pluginName][key] = consumer.Name
 	}
 	return nil
-}
-
-// Plugin Define the plugin interface
-type Plugin interface {
-	Name() string
-	NewConfig() PluginConsumerConfig
-}
-
-type PluginConsumerConfig interface {
-	Index() string
-}
-
-// Global plugin registry
-var pluginRegistry = make(map[string]Plugin)
-
-func RegisterPlugin(plugin Plugin) {
-	pluginRegistry[plugin.Name()] = plugin
 }

--- a/controller/internal/controller/consumer_controller_test.go
+++ b/controller/internal/controller/consumer_controller_test.go
@@ -1,0 +1,204 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	mosniov1 "mosn.io/htnn/types/apis/v1"
+)
+
+func TestCheckConsumerConflicts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	mosniov1.AddToScheme(scheme)
+
+	tests := []struct {
+		name    string
+		setup   func() []mosniov1.Consumer
+		wantErr bool
+	}{
+		{
+			name: "no consumers",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{}
+			},
+			wantErr: false,
+		},
+		{
+			name: "single consumer no conflict",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumer("ns1", "consumer1", map[string]interface{}{
+						"key": "value1",
+					}),
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple consumers different namespaces no conflict",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumer("ns1", "consumer1", map[string]interface{}{
+						"key": "value1",
+					}),
+					createTestConsumer("ns2", "consumer2", map[string]interface{}{
+						"key": "value1",
+					}),
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple consumers same namespace different plugins no conflict",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumerWithPlugins("ns1", "consumer1", map[string]map[string]interface{}{
+						"plugin1": {"key": "value1"},
+					}),
+					createTestConsumerWithPlugins("ns1", "consumer2", map[string]map[string]interface{}{
+						"plugin2": {"key": "value1"},
+					}),
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "conflict in same namespace and plugin",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumer("ns1", "consumer1", map[string]interface{}{
+						"key": "value1",
+					}),
+					createTestConsumer("ns1", "consumer2", map[string]interface{}{
+						"key": "value1",
+					}),
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid config",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "consumer1",
+							Namespace: "ns1",
+						},
+						Spec: mosniov1.ConsumerSpec{
+							Auth: map[string]mosniov1.ConsumerPlugin{
+								"plugin1": {
+									Config: runtime.RawExtension{
+										Raw: []byte("invalid json"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "no key field",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumer("ns1", "consumer1", map[string]interface{}{
+						"other_field": "value",
+					}),
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "issuer field as key",
+			setup: func() []mosniov1.Consumer {
+				return []mosniov1.Consumer{
+					createTestConsumer("ns1", "consumer1", map[string]interface{}{
+						"issuer": "issuer-value",
+					}),
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumers := tt.setup()
+			objects := make([]client.Object, 0, len(consumers))
+			for i := range consumers {
+				objects = append(objects, &consumers[i])
+			}
+
+			r := &ConsumerReconciler{
+				ResourceManager: newTestResourceManager(scheme, objects...),
+				keyIndex:        NewKeyIndexRegistry(),
+			}
+
+			err := r.checkConsumerConflicts(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkConsumerConflicts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func createTestConsumer(namespace, name string, config map[string]interface{}) mosniov1.Consumer {
+	return createTestConsumerWithPlugins(namespace, name, map[string]map[string]interface{}{
+		"test-plugin": config,
+	})
+}
+
+func createTestConsumerWithPlugins(namespace, name string, plugins map[string]map[string]interface{}) mosniov1.Consumer {
+	authPlugins := make(map[string]mosniov1.ConsumerPlugin)
+	for pluginName, config := range plugins {
+		raw, _ := json.Marshal(config)
+		authPlugins[pluginName] = mosniov1.ConsumerPlugin{
+			Config: runtime.RawExtension{Raw: raw},
+		}
+	}
+
+	return mosniov1.Consumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mosniov1.ConsumerSpec{
+			Auth: authPlugins,
+		},
+	}
+}
+
+type testResourceManager struct {
+	client  client.Client
+	objects []client.Object
+}
+
+func (m *testResourceManager) Get(ctx context.Context, key client.ObjectKey, out client.Object) error {
+	return m.client.Get(ctx, key, out)
+}
+
+func (m *testResourceManager) List(ctx context.Context, list client.ObjectList) error {
+	return m.client.List(ctx, list)
+}
+
+func (m *testResourceManager) UpdateStatus(ctx context.Context, obj client.Object, statusPtr any) error {
+	return nil
+}
+
+func newTestResourceManager(scheme *runtime.Scheme, objects ...client.Object) *testResourceManager {
+	return &testResourceManager{
+		client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objects...).
+			Build(),
+		objects: objects,
+	}
+}


### PR DESCRIPTION
<!--
Please uncomment and change the [issue] below to the number of issue which is
addressed by this pull request if there is one.
If the pull request references an issue X but does not close it, please change the
prompt to "Ref #X".
-->

Fix #618 

<!--
Before submitting a pull request, please make sure the following is done:
* If your change is a bugfix, please add tests which can reproduce the bug.
* If your change is a new feature, please add tests which cover the new functionality, and
update the doc under `site/content/`. You can update one of the doc written in your familiar language.
It's appreciated if you can update both the English and Chinese doc if you know both languages.

If you want to add an E2E test, please add it in `e2e/tests/`.
If you want to add an integration test, please add it in (depending which module you are working on):
* ./api/tests/integration
* ./plugins/tests/integration
* ./controller/tests/integration

You can run the test in the CI by enabling GitHub Action in your own fork and submitting a pull request
to your own fork. Alternatively, you can run the test locally by following the instructions in the CI configuration.

Feel free to ask for help if you need.

If your pull request is still in progress, you can submit a draft PR:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request.

Once your pull request is ready for review, please don't use `push -f` which will break the review progress.
Please use `merge main` to resolve merge conflicts, instead of `rebase main`.
Please use "request review" to notify the reviewer after making changes:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.
Or you can @ the reviewer in the comment to notify the reviewer.
-->
Main features:
1.Full collision detection: The checkConsumerConflicts method checks all Consumer resources to see if there is a configuration conflict between them
2.Three-level index structure: a three-level index structure of Namespace → PluginName → Key → ConsumerName is established
3.Collision detection rules: the same Key of the same Plugin under the same Namespace can only be used by one Consumer

There are also some unit tests below.

Looking forward to review!