### PR TITLE
opa: add ability to pass the auth response to the client response when denied

### DIFF
--- a/plugins/plugins/opa/config.go
+++ b/plugins/plugins/opa/config.go
@@ -76,7 +76,10 @@ func (conf *config) Init(cb api.ConfigCallbackHandler) error {
 	ctx := context.Background()
 
 	query, _ := rego.New(
-		rego.Query(fmt.Sprintf("allow = data.%s.allow", policy)),
+		rego.Query(fmt.Sprintf(`
+            allow = data.%[1]s.allow;
+            custom_response = object.get(data.%[1]s, "custom_response", null)
+        `, policy)),
 		rego.Module(fmt.Sprintf("%s.rego", policy), module),
 	).PrepareForEval(ctx)
 	conf.query = query

--- a/plugins/tests/integration/opa_test.go
+++ b/plugins/tests/integration/opa_test.go
@@ -54,14 +54,19 @@ func TestOpa(t *testing.T) {
 				resp, err := dp.Get("/echo", nil)
 				require.Nil(t, err)
 				assert.Equal(t, 200, resp.StatusCode)
-				resp, _ = dp.Get("/x", nil)
+				resp.Body.Close()
+
+				resp, err = dp.Get("/x", nil)
+				require.Nil(t, err)
 				assert.Equal(t, 401, resp.StatusCode)
 				assert.Equal(t, "Bearer realm=\"api\"", resp.Header.Get("WWW-Authenticate"))
 				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
-				body, err := io.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				require.Nil(t, err)
-				assert.Contains(t, string(body), "Authentication required")
+				resp.Body.Close()
+
+				assert.Contains(t, string(bodyBytes), "Authentication required")
 			},
 		},
 		{
@@ -76,11 +81,11 @@ func TestOpa(t *testing.T) {
 							startswith(request.path, "/echo")
 						}
 						custom_response := {
-							"msg": "Authentication required. Please provide valid authorization header.",
+							"body": "Authentication required. Please provide valid authorization header.",
 							"status_code": 401,
 							"headers": {
 								"WWW-Authenticate": ["Bearer realm=\"api\""],
-								"Content-Type": ["application/json"]
+								"content-type": ["application/json"]
 							}
 						} {
 							request.method == "GET"
@@ -92,10 +97,19 @@ func TestOpa(t *testing.T) {
 				resp, err := dp.Get("/echo", nil)
 				require.Nil(t, err)
 				assert.Equal(t, 200, resp.StatusCode)
-				resp, _ = dp.Get("/x", nil)
+				resp.Body.Close()
+
+				resp, err = dp.Get("/x", nil)
+				require.Nil(t, err)
 				assert.Equal(t, 401, resp.StatusCode)
 				assert.Equal(t, "Bearer realm=\"api\"", resp.Header.Get("WWW-Authenticate"))
 				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+				bodyBytes, err := io.ReadAll(resp.Body)
+				require.Nil(t, err)
+				resp.Body.Close()
+
+				assert.Contains(t, string(bodyBytes), "Authentication required. Please provide valid authorization header.")
 			},
 		},
 	}

--- a/plugins/tests/integration/testdata/services/docker-compose.yml
+++ b/plugins/tests/integration/testdata/services/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     image: openpolicyagent/opa:0.58.0
     restart: unless-stopped
     ports:
-      - 8181:8181
+      - "8181:8181"
     command: run -s /test.rego
     volumes:
       - type: bind

--- a/plugins/tests/integration/testdata/services/opa/test.rego
+++ b/plugins/tests/integration/testdata/services/opa/test.rego
@@ -24,7 +24,7 @@ allow {
 }
 
 custom_response = {
-    "msg": "Authentication required. Please provide valid authorization header.",
+    "body": "Authentication required. Please provide valid authorization header.",
     "status_code": 401,
     "headers": {
         "WWW-Authenticate": ["Bearer realm=\"api\""],

--- a/plugins/tests/integration/testdata/services/opa/test.rego
+++ b/plugins/tests/integration/testdata/services/opa/test.rego
@@ -22,3 +22,15 @@ allow {
     request.method == "GET"
     startswith(request.path, "/echo")
 }
+
+custom_response = {
+    "msg": "Authentication required. Please provide valid authorization header.",
+    "status_code": 401,
+    "headers": {
+        "WWW-Authenticate": ["Bearer realm=\"api\""],
+        "Content-Type": ["application/json"]
+    }
+} {
+    request.method == "GET"
+    startswith(request.path, "/x")
+}

--- a/site/content/en/docs/reference/plugins/opa.md
+++ b/site/content/en/docs/reference/plugins/opa.md
@@ -91,7 +91,7 @@ Here is the JSON data OPA sends back to HTNN, set by the configured policy:
     "allow": true
   },
   "custom_response": {
-    "msg": "Authentication required. Please provide valid authorization header.",
+    "body": "Authentication required. Please provide valid authorization header.",
     "status_code": 401,
     "headers": {
       "WWW-Authenticate": [
@@ -220,23 +220,11 @@ HTTP/1.1 403 Forbidden
 
 #### Field Format
 
-* **`msg`**
-  This field follows the same behavior as the `Msg` field in the `LocalResponse` structure. If `msg` is not empty, its content
-  will be processed according to the following rules when constructing the response body sent to the client:
-
-    1. If a `Content-Type` header is explicitly set, the `msg` will be sent as-is.
-    2. If `Content-Type` is `"application/json"`, the `msg` will be wrapped as:
-
-       ```json
-       { "msg": "..." }
-       ```
-
-       (Refer to the `DefaultJSONResponse` structure for details.)
-    3. If no `Content-Type` is provided, or it is `"application/json"`, the message will also be wrapped as JSON.
-    4. For all other content types, the message will be returned as a raw string.
+* **`body`**
+  This field represents the message body sent to the client. **If this field exists but no Content-Type is set in the headers,** the plugin will automatically add Content-Type: text/plain as the default.
 
 * **`status_code`**
-  The HTTP status code. This field supports numeric values.
+  HTTP status code. This field supports numeric values.
 
 * **`headers`**
   HTTP response headers. Each header value must be represented as an array of strings.
@@ -252,7 +240,7 @@ allow {
     startswith(request.path, "/echo")
 }
 custom_response = {
-    "msg": "Authentication required. Please provide valid authorization header.",
+    "body": "Authentication required. Please provide valid authorization header.",
     "status_code": 401,
     "headers": {
         "WWW-Authenticate": ["Bearer realm=\"api\""],
@@ -271,8 +259,8 @@ In this example:
 
 #### Notes
 
-When working with a remote OPA service, `custom_response` should be added as part of the policy decision result. For the expected JSON format returned by OPA, refer to the **Data Exchange** section.
+1. When working with a remote OPA service, `custom_response` should be added as part of the policy decision result. For the expected JSON format returned by OPA, refer to the **Data Exchange** section.
 
-If `allow` is `true`, the `custom_response` will be ignored by plugin.
+2. If `allow` is `true`, the `custom_response` will be ignored by plugin.
 
-If some or all fields under `custom_response` are missing in the response, please ensure that the field names and types conform to the expected format.
+3. If some or all fields under `custom_response` are missing in the response, please ensure that the field names and types conform to the expected format.

--- a/site/content/en/docs/reference/plugins/opa.md
+++ b/site/content/en/docs/reference/plugins/opa.md
@@ -221,7 +221,7 @@ HTTP/1.1 403 Forbidden
 #### Field Format
 
 * **`body`**
-  This field represents the message body sent to the client. **If this field exists but no Content-Type is set in the headers,** the plugin will automatically add Content-Type: text/plain as the default.
+  This field represents the message body sent to the client. **If this field exists but no Content-Type is set in the headers, the plugin will automatically add `Content-Type: text/plain` as the default**.
 
 * **`status_code`**
   HTTP status code. This field supports numeric values.

--- a/site/content/zh-hans/docs/reference/plugins/opa.md
+++ b/site/content/zh-hans/docs/reference/plugins/opa.md
@@ -91,7 +91,7 @@ OPA 策略应该定义一个布尔值 `allow` 并使用它来指示请求是否�
     "allow": true
   },
   "custom_response": {
-    "msg": "Authentication required. Please provide valid authorization header.",
+    "body": "Authentication required. Please provide valid authorization header.",
     "status_code": 401,
     "headers": {
       "WWW-Authenticate": [
@@ -216,25 +216,14 @@ HTTP/1.1 403 Forbidden
 
 #### 字段格式
 
-* **`msg`**
-  此字段的行为与 `LocalResponse` 结构中的 `Msg` 字段一致。如果 `msg` 不为空，其内容将在构造返回给客户端的响应体时，按照以下规则进行处理：
-
-  1. 如果显式设置了 `Content-Type` 响应头，则 `msg` 将原样发送。
-  2. 如果 `Content-Type` 是 `"application/json"`，则 `msg` 会被包装为以下 JSON 格式：
-
-     ```json
-     { "msg": "..." }
-     ```
-
-     （具体实现可参考 `DefaultJSONResponse` 结构体。）
-  3. 如果没有提供 `Content-Type`，或者值为 `"application/json"`，则消息也会被包装为 JSON 格式。
-  4. 对于其他内容类型，消息将以原始字符串形式返回。
+* **`body`**
+  该字段表示发送给客户端的消息体。**如果该字段存在，但在 headers 中未配置 Content-Type，插件将默认添加 Content-Type: text/plain。**
 
 * **`status_code`**
   HTTP 状态码。此字段支持数值类型。
 
 * **`headers`**
-  HTTP 响应头。每个头部的值必须以字符串数组形式表示。
+  HTTP 响应头。每个头部的值必须以**字符串数组**形式表示。
 
 #### 示例
 
@@ -247,7 +236,7 @@ allow {
     startswith(request.path, "/echo")
 }
 custom_response = {
-    "msg": "Authentication required. Please provide valid authorization header.",
+    "body": "Authentication required. Please provide valid authorization header.",
     "status_code": 401,
     "headers": {
         "WWW-Authenticate": ["Bearer realm=\"api\""],
@@ -266,10 +255,10 @@ custom_response = {
 
 #### 注意事项
 
-在使用远程 OPA 服务时，`custom_response` 应作为策略决策结果的一部分返回。有关 OPA 返回的 JSON 格式的详细信息，请参考 **数据交换** 部分。
+1. 在使用远程 OPA 服务时，`custom_response` 应作为策略决策结果的一部分返回。有关 OPA 返回的 JSON 格式的详细信息，请参考 **数据交换** 部分。
 
-如果 `allow` 为 `true`，则 `custom_response` 将被插件忽略。
+2. 如果 `allow` 为 `true`，则 `custom_response` 将被插件忽略。
 
-如果您在响应中未看到 `custom_response` 字段的部分或全部内容，请确认字段名称和类型是否符合规范。
+3. 如果您在响应中未看到 `custom_response` 字段的部分或全部内容，请确认字段名称和类型是否符合规范。
 
 


### PR DESCRIPTION
Fix #48

### Summary

This PR add support for custom response

### Changes

- Added support for `custom_response` in both local and remote OPA services.
- Added unit tests for `custom_response` handling.
- Added integration tests for `custom_response`.
- Added English and Chinese documentation for `custom_response`.
